### PR TITLE
also build manifest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,66 @@
 #!/bin/bash
+# (pushd/popd needs an advanced shell)
 
 set -e
 
 SCRIPTDIR=$(dirname $0)
 
+print_usage() {
+    echo "Usage: $0 [GLUON_BRANCH]"
+    echo ''
+    echo 'If GLUON_BRANCH is not given, experimental is set.'
+    echo ''
+    echo 'Options:'
+    echo '  -h  show this help'
+}
+
+# command line options handling
+ARGS=`getopt h $*`
+if [ $? -ne 0 ]
+then
+    print_usage
+    exit 2
+fi
+set -- $ARGS
+
+while true
+do
+    case "$1" in
+        -h)
+            print_usage
+            exit 0
+            ;;
+        --)
+            shift; break;;
+    esac
+done
+
+# set GLUON_BRANCH for manifest
+if [ -z "$1" ]
+then
+    GLUON_BRANCH=experimental
+    echo 'Set GLUON_BRANCH to "experimental"!'
+else
+    GLUON_BRANCH=$1
+fi
+
+case "xx$GLUON_BRANCH" in
+    'xxstable'|'xxbeta'|'xxexperimental')
+        # fine
+        ;;
+    *)
+        echo "Unknown GLUON_BRANCH '$1'."
+        echo 'Use "stable", "beta", or "experimental"!'
+        exit 1
+        ;;
+esac
+
+# get GLUON_CHECKOUT from site dir
 pushd ${SCRIPTDIR}
 eval `make -s -f helper.mk`
 echo "GLUON_CHECKOUT: ${GLUON_CHECKOUT}"
 
+# build
 pushd ..
 git checkout master
 git pull
@@ -15,9 +68,11 @@ git checkout ${GLUON_CHECKOUT}
 make clean
 make update
 make all -j4
-make manifest
+GLUON_BRANCH=${GLUON_BRANCH} make manifest
 popd
 
 popd
 
 exit 0
+
+# vim: set et sts=0 ts=4 sw=4 sr:


### PR DESCRIPTION
build-script was ich aus hamburg oder lübeck bekommen hatte:

```
#!/bin/bash

set -e

export GLUON_BRANCH=experimental
export GLUON_IMAGEDIR=$(mktemp -d)

pushd gluon
git pull
git -C site pull
make update
make clean
make all BROKEN=1
make manifest BROKEN=1
popd

mv $GLUON_IMAGEDIR/sysupgrade/experimental.manifest $GLUON_IMAGEDIR/sysupgrade/manifest

gluon/contrib/sign.sh nightly.secret $GLUON_IMAGEDIR/sysupgrade/manifest

tar cf firmwares.tar -C $GLUON_IMAGEDIR/ .

rm -rf $GLUON_IMAGEDIR
```

Die machen bisschen was anders und haben das build skript nicht im site repo, entscheidend ist, dass das manifest nicht mit gebaut wird, wenn man nicht `make manifest` aufruft.

Noch NICHT getestet.
