### PR TITLE
Texte für die Registrierungsseite überarbeitet

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -135,10 +135,8 @@ Freifunk-Knoten. Fülle das folgende Formular Deinen Vorstellungen
 entsprechend aus und sende es ab.
 ]],
         msg_nopubkey = [[
-Bitte folge dem
-<a href="http://register.md.freifunk.net/#new?hostname=<%=hostname%>&key=<%=pubkey%>&mac=<%= sysconfig.primary_mac %>"
-   alt="FreifunkMD Registrierung von <%=hostname%>">Registrierungslink für Deinen Knoten <em><%=hostname%></em></a>,
-um die Einrichtung abzuschließen und Deinen Knoten bekanntzugeben.
+        Der Abschnitt wird für FFMD nicht gebraucht. Solltest Du diesen 
+        Text sehen, wende Dich bitte an die Entwickler!
 ]],
         msg_pubkey = [[
 Dies ist der öffentliche Schlüssel Deines Freifunkknotens. 


### PR DESCRIPTION
Ich habe die Texte ein wenig überarbeitet, insbesondere folgende Aspekte:
- Formulierungen
- Die Links in msg_pubkey haben nun das tatsächliche Ziel als Label.
  Einen Link mit allen Parametern für die Konfiguration mit
  "http://register.freifunk.md" zu labeln kann den Nutzer verwirren,
  weil beim klick auf den Link mehr passiert, als das Label vermuten lässt.
- msg_nopubkey wurde dementsprechend angepasst.

Allerdings habe ich hier keine Build-Umgebung zum Testen — das müsste noch gemacht werden.
