### PR TITLE
Repo vor Branch-Wechsel bereinigen

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,7 @@ echo "GLUON_CHECKOUT: ${GLUON_CHECKOUT}"
 
 # build
 pushd ..
+make clean $VERBOSE
 git checkout master
 git pull
 git checkout ${GLUON_CHECKOUT}


### PR DESCRIPTION
"make clean $VERBOSE" before "git checkout master"

13:52 < LeSpocky> aber vielleicht sollte ich das make clean vor den wechsel des
                  branches tun
13:53 < LeSpocky> bzw. noch ein weiteres vor den checkout vom master tun
13:53 < LeSpocky> dann passt das nämlich auch zusammen
13:55 < LeSpocky> _MrTux_: füg mal testweise in build.sh ein `make clean
                  $VERBOSE` vor `git checkout master` ein, wenn es immernoch
                  nicht geht
