### PR TITLE
upgrade to gluon 2014.4 and activate private-wlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Verify a successful upgrade by
 Gluon versions used for specific Freifunk Magdeburg Firmware builds
 -------------------------------------------------------------------
 
+* 0.31: *gluon 2014.4*
+  * see http://gluon.readthedocs.org/en/latest/releases/v2014.4.html
+  * enabled `gluon-neighbour-info`
 * 0.30: *gluon 2014.3.1*
   * see http://gluon.readthedocs.org/en/latest/releases/v2014.3.1.html
   * enable mesh VPN by default

--- a/site.mk
+++ b/site.mk
@@ -1,18 +1,27 @@
 # http://stackoverflow.com/questions/18136918/how-to-get-current-directory-of-your-makefile
 this_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
+##	GLUON_SITE_PACKAGES
+#		specify gluon/openwrt packages to include here
+#
+#		The gluon-mesh-batman-adv-* package must come first because of
+#		the dependency resolution!
 GLUON_SITE_PACKAGES := \
+	gluon-mesh-batman-adv-14 \
 	gluon-alfred \
 	gluon-announced \
 	gluon-autoupdater \
-	gluon-config-mode \
+	gluon-config-mode-autoupdater \
+	gluon-config-mode-hostname \
+	gluon-config-mode-mesh-vpn \
+	gluon-config-mode-geo-location \
+	gluon-config-mode-contact-info \
 	gluon-ebtables-filter-multicast \
 	gluon-ebtables-filter-ra-dhcp \
 	gluon-luci-admin \
 	gluon-luci-autoupdater \
 	gluon-luci-portconfig \
 	gluon-next-node \
-	gluon-mesh-batman-adv \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-status-page \

--- a/site.mk
+++ b/site.mk
@@ -21,6 +21,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-admin \
 	gluon-luci-autoupdater \
 	gluon-luci-portconfig \
+	gluon-luci-private-wifi \
 	gluon-next-node \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \

--- a/site.mk
+++ b/site.mk
@@ -23,6 +23,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-portconfig \
 	gluon-luci-private-wifi \
 	gluon-next-node \
+	gluon-neighbour-info \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-status-page \
@@ -30,7 +31,7 @@ GLUON_SITE_PACKAGES := \
 	iptables \
 	haveged
 
-DEFAULT_GLUON_CHECKOUT := v2014.3.1
+DEFAULT_GLUON_CHECKOUT := v2014.4
 # Allow overriding the checkout from the command line
 GLUON_CHECKOUT ?= $(DEFAULT_GLUON_CHECKOUT)
 


### PR DESCRIPTION
Das sind gesammelte vier Commits. Die Version läuft seit einer Woche als experimental, u.a. auf dem TL-WR841ND im Space, der dort auch private WLAN macht. Es enthält damit den Fix für #15. Alles weitere für v0.31 dann aufbauend auf diesem hier. :turtle: