### PR TITLE
v0.31.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Gluon versions used for specific Freifunk Magdeburg Firmware builds
   * enabled `gluon-neighbour-info`
   * make IPv6 connections to gateways possible and add optional addresses
   * changed fastd auth method from gmac to umac
+  * allow to configure a private WLAN which is bridged with the WAN uplink
 * 0.30: *gluon 2014.3.1*
   * see http://gluon.readthedocs.org/en/latest/releases/v2014.3.1.html
   * enable mesh VPN by default

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Gluon versions used for specific Freifunk Magdeburg Firmware builds
   * see http://gluon.readthedocs.org/en/latest/releases/v2014.4.html
   * enabled `gluon-neighbour-info`
   * make IPv6 connections to gateways possible and add optional addresses
+  * changed fastd auth method from gmac to umac
 * 0.30: *gluon 2014.3.1*
   * see http://gluon.readthedocs.org/en/latest/releases/v2014.3.1.html
   * enable mesh VPN by default

--- a/site.conf
+++ b/site.conf
@@ -3,7 +3,7 @@
     site_name = 'Freifunk Magdeburg',
     site_code = 'ffmd',
 
-    prefix4 = '10.139.0.0/17',                  -- neue MD IPv4 Range
+    prefix4 = '10.139.0.0/16',                  -- neue MD IPv4 Range
     prefix6 = 'fda9:026e:5805::/64',            -- neue MD  IPv6 Range
 
     timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',    -- Europe/Berlin

--- a/site.conf
+++ b/site.conf
@@ -40,7 +40,7 @@
 
     fastd_mesh_vpn = {
         enabled = true,
-        methods = {'salsa2012+gmac'},
+        methods = {'salsa2012+umac'},
         mtu = 1426,
         backbone = {
             limit = 2,

--- a/site.conf
+++ b/site.conf
@@ -45,7 +45,7 @@
         backbone = {
             limit = 2,
             peers = {
-                fastd1 = {
+                gw1 = {
                     key = '4cd9f8cafd8ee0b24378651252815ddc731d55c4db3c9644d8ee860ecc8df5d2',
                     remotes = {
                         '"gw1.md.freifunk.net" port 10000',
@@ -53,7 +53,7 @@
                         'ipv4 "37.120.160.206" port 10000',
                     },
                 },
-                fastd2 = {
+                gw2 = {
                     key = '23731bc411ef17129163bfedc5ecc7f5df05d46fed0f56d92028d082704474be',
                     remotes = {
                         '"gw2.md.freifunk.net" port 10000',


### PR DESCRIPTION
drei kleinere Sachen für v0.31 noch. Eins ist Kosmetik. Das andere die Änderung von /17 auf /16 für IPv4, wobei das keine Auswirkungen zu haben scheint und das dritte die Änderung des Crypto-Algorithmus für fastd. Siehe dazu die entsprechenden Tickets. Getestet von mir grad eben erfolgreich mit TP-Link TL-MR3020.