### PR TITLE
fix #53 by replacing the first dash in version string depending on br…

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -39,9 +39,9 @@ DEFAULT_GLUON_CHECKOUT := v2015.1.1
 GLUON_CHECKOUT ?= $(DEFAULT_GLUON_CHECKOUT)
 
 # replace magic in version number as follows:
-# v0.31-4-gf390c9d				--> v0.31+4-gf390c9d
-# v0.32-beta.1 					--> v0.32~beta.1
-# v0.32~beta.1-2-f00b445-dirty	--> v0.32~beta.1+2-f00b445-dirty
+# v0.31-4-gf390c9d				--> 0.31+4-gf390c9d
+# v0.32-beta.1 					--> 0.32~beta.1
+# v0.30-beta.1-2-g11c8a08-dirty	--> 0.30~beta.1+2-g11c8a08-dirty
 DEFAULT_GLUON_RELEASE := $(shell git --git-dir=$(this_dir)/.git \
 		--work-tree=$(this_dir) describe --tags --always --dirty \
 		--match "v*" \

--- a/site.mk
+++ b/site.mk
@@ -38,7 +38,17 @@ DEFAULT_GLUON_CHECKOUT := v2015.1.1
 # Allow overriding the checkout from the command line
 GLUON_CHECKOUT ?= $(DEFAULT_GLUON_CHECKOUT)
 
-DEFAULT_GLUON_RELEASE := $(shell git --git-dir=$(this_dir)/.git --work-tree=$(this_dir) describe --tags --always --dirty --match "v*" | sed 's/^v//')
+# replace magic in version number as follows:
+# v0.31-4-gf390c9d				--> v0.31+4-gf390c9d
+# v0.32-beta.1 					--> v0.32~beta.1
+# v0.32~beta.1-2-f00b445-dirty	--> v0.32~beta.1+2-f00b445-dirty
+DEFAULT_GLUON_RELEASE := $(shell git --git-dir=$(this_dir)/.git \
+		--work-tree=$(this_dir) describe --tags --always --dirty \
+		--match "v*" \
+		| sed -e 's/^\(v[^-]\+\)-\([0-9]\+-g[0-9a-f]\{7\}.*\)$$/\1+\2/' \
+		| sed -e 's/^\(v[^-]\+\)-\(beta.*\)$$/\1~\2/' \
+		| sed -e 's/^\(v[^~]\+~beta[^-]\+\)-\([0-9]\+-g[0-9a-f]\{7\}.*\)$$/\1+\2/' \
+		| sed -e 's/^v//')
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)


### PR DESCRIPTION
…anch

actually for beta first '-' is replaced by '~', for experimental first
'-' is replaced by '+' with an additional rule for experimental builds following a beta tag. This allows version order recognized by opkg as
follows:

v0.31~beta.1 < v0.31 < v0.31+1-gf00b455 < v0.32~beta.1 < v0.32~beta.1+1-gfad0123

And even more:

v0.31~beta.1-dirty < v0.31~beta.1+2-g1234567
v0.32-dirty < v0.32+3-g7654321 < v0.32+3-g7654321-dirty

Ich hoffe, ich habe keine Fehler in die Reg-Ex gebaut. Testen ist leider nicht so ganz trivial, weil man diese changes hier extrahieren müsste, verschiedene alte Versionsstände auschecken und dagegen prüfen. Fehler finden in RegEx durch scharf klappt vielleicht auch? ;-)