### PR TITLE
bump to v2016.1.2 (for release 0.36)

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -33,7 +33,7 @@ GLUON_SITE_PACKAGES := \
 	iptables \
 	iwinfo
 
-DEFAULT_GLUON_CHECKOUT := v2016.1.1
+DEFAULT_GLUON_CHECKOUT := v2016.1.2
 
 # Allow overriding the checkout from the command line
 GLUON_CHECKOUT ?= $(DEFAULT_GLUON_CHECKOUT)


### PR DESCRIPTION
update gluon to lastest release