### PR TITLE
add GW with MTU 1280

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -100,26 +100,43 @@
       backbone = {
         -- Limit number of connected peers to reduce bandwidth.
         limit = 2,
-
-        -- List of peers.
-        peers = {
+        -- List of peers. (MTU1426)
+        --peers = {
+        --  gw1 = {
+        --    key = '4cd9f8cafd8ee0b24378651252815ddc731d55c4db3c9644d8ee860ecc8df5d2',
+        --    -- MTU1246)
+        --   remotes = {
+        --      '"gw1.md.freifunk.net" port 10000',
+        --      'ipv6 "2a03:4000:6:30c3::32" port 10000',
+        --      'ipv4 "37.120.160.206" port 10000',
+        --    },
+        --  },
+        --  gw2 = {
+        --    key = '23731bc411ef17129163bfedc5ecc7f5df05d46fed0f56d92028d082704474be',
+        --    -- You can also omit the ipv4 to allow both connection via ipv4 and ipv6
+        --    remotes = {
+        --      '"gw2.md.freifunk.net" port 10000',
+        --      'ipv6 "2a01:4a0:2002:2189::64" port 10000',
+        --      'ipv4 "130.185.109.142" port 10000',
+        --    },
+        --  },
+        -- },
+       peers = {-- MTU1280
           gw1 = {
-            key = '4cd9f8cafd8ee0b24378651252815ddc731d55c4db3c9644d8ee860ecc8df5d2',
-
-            -- This is a list, so you might add multiple entries.
+            key = '3a521a92367c27156483edb5077947c38da8c7959c139b19361309b43c26b9be',
             remotes = {
-              '"gw1.md.freifunk.net" port 10000',
-              'ipv6 "2a03:4000:6:30c3::32" port 10000',
-              'ipv4 "37.120.160.206" port 10000',
+              '"gw1.md.freifunk.net" port 10001',
+              'ipv6 "2a03:4000:6:30c3::32" port 10001',
+              'ipv4 "37.120.160.206" port 10001',
             },
           },
           gw2 = {
-            key = '23731bc411ef17129163bfedc5ecc7f5df05d46fed0f56d92028d082704474be',
+            key = '2c39c2d4839f23620b489e8d3a089565939ace1e31980b0af2a27e052e82dc70',
             -- You can also omit the ipv4 to allow both connection via ipv4 and ipv6
             remotes = {
-              '"gw2.md.freifunk.net" port 10000',
-              'ipv6 "2a01:4a0:2002:2189::64" port 10000',
-              'ipv4 "130.185.109.142" port 10000',
+              '"gw2.md.freifunk.net" port 10001',
+              'ipv6 "2a01:4a0:2002:2189::64" port 10001',
+              'ipv4 "130.185.109.142" port 10001',
             },
           },
         },


### PR DESCRIPTION
Zum Testen der geringeren MTU. Auf GW2 wurde bereits eine zweite fastd Instanz mit MTU1280 erstellt. Für jede Fastd Verbindung gibt es ein Schlüsselpaar.

Übersicht:
 KEY1 gw1.md.freifunk.net (MTU1426)
    Public: 4cd9f8cafd8ee0b24378651252815ddc731d55c4db3c9644d8ee860ecc8df5d2

KEY2 gw2.md.freifunk.net (MTU1426)
    Public: 23731bc411ef17129163bfedc5ecc7f5df05d46fed0f56d92028d082704474be

KEY3 gw3.md.freifunk.net (MTU1426)
    Public: 85f2c53539d2bc611e5b1fbef8c3062c13f9d42b5a60556705c1232345da4784

KEY4 gw1.md.freifunk.net (MTU 1280)
    Public: 3a521a92367c27156483edb5077947c38da8c7959c139b19361309b43c26b9be

KEY5 gw2.md.freifunk.net (MTU 1280)
    Public: 2c39c2d4839f23620b489e8d3a089565939ace1e31980b0af2a27e052e82dc70

KEY6 gw3.md.freifunk.net (MTU 1280)
    Public: 0838587a7f857e878710098bcd55eaa49c09058c38c0a99713435b1d567e6980
