### PR TITLE
Merge changes from gluon site-example

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2015.1+
+-- This is an example site configuration for Gluon v2016.2.7
 --
 -- Take a look at the documentation located at
 -- http://gluon.readthedocs.org/ for details.
@@ -15,7 +15,9 @@
   -- Shorthand of the community.
   site_code = 'ffmd',
 
-  -- Prefixes used within the mesh. Both are required.
+  -- Prefixes used within the mesh.
+  -- prefix6 is required, prefix4 can be omitted if next_node.ip4
+  -- is not set.
   prefix4 = '10.139.0.0/17',
   prefix6 = 'fda9:026e:5805::/64',
 
@@ -37,6 +39,14 @@
   wifi24 = {
     -- Wireless channel.
     channel = 1,
+
+    -- List of supported wifi rates (optional)
+    -- Example removes 802.11b compatibility for better performance
+    supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
+
+    -- List of basic wifi rates (optional, required if supported_rates is set)
+    -- Example removes 802.11b compatibility for better performance
+    basic_rate = {6000, 9000, 18000, 36000, 54000},
 
     -- ESSID used for client network.
     ap = {
@@ -221,6 +231,18 @@
   -- setup_mode = {
   --  skip = true,
   -- },
+
+  -- config_mode = {
+    -- Show/hide the altitude field
+    -- geo_location = {
+      -- show_altitude = false,
+    -- },
+    -- define if the contact field is obligatory (optional)
+    -- owner = {
+      -- obligatory = true
+    -- },
+  -- },
+
 }
 
 -- vim: set ft=lua et sts=0 ts=2 sw=2 sr:

--- a/site.mk
+++ b/site.mk
@@ -69,11 +69,11 @@ GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 # Default priority for updates.
 GLUON_PRIORITY ?= 0
 
+# Region code required for some images; supported values: us eu
+GLUON_REGION ?= eu
+
 # Languages to include
 GLUON_LANGS ?= en de
-
-# Changes v2016.1.x
-GLUON_REGION ?= eu
 
 # Changes v2016.2.7
 GLUON_ATH10K_MESH ?= ibss


### PR DESCRIPTION
Gluon contains an example for the subfolder `site` below
`docs/site-example`. This merges not yet applied changes from the
v2016.2.7 example to our `site.conf` and `site.mk` files.

This introduces options `supported_rates` and `basic_rate` in file
`site.conf` which "removes 802.11b compatibility for better
performance".