### PR TITLE
Fix IPv6 address for gw1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
   * Change MTU to 1312 with fastd on port 10001.
   * Removed Registration of VPN keys. It is not longer necessary to register the VPN keys.
   * set vpn peer limit to 1 to reduce load on freifunk nodes.
+  * Fix IPv6 address for gateway gw1
 * 0.38: *gluon 2016.2.7*
   * see https://gluon.readthedocs.io/en/v2016.1.6/releases/v2016.1.6.html
   * see https://gluon.readthedocs.io/en/v2016.2/releases/v2016.2.html

--- a/site.conf
+++ b/site.conf
@@ -121,7 +121,7 @@
             -- This is a list, so you might add multiple entries.
             remotes = {
               '"gw1.md.freifunk.net" port 10001',
-              'ipv6 "2a03:4000:6:30c3::32" port 10001',
+              'ipv6 "2a03:4000:6:30c3::1" port 10001',
               'ipv4 "37.120.160.206" port 10001',
             },
           },


### PR DESCRIPTION
As @LeSpocky remarked in https://github.com/FreifunkMD/FFMD-Orga/issues/37, the v6 address for gw1 does not match reality. This merge fixes the address.